### PR TITLE
Fixes #104 On pull_request workflows are not triggered when pull request is created from the GH-Action create-reports.yml

### DIFF
--- a/.github/workflows/create-reports.yml
+++ b/.github/workflows/create-reports.yml
@@ -113,6 +113,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
+        token: ${{ secrets.PAT_PR_TRIGGERED_BY_ACTIONS }}
         branch: ${{ github.ref_name }}-${{ matrix['Repository name'] }}
         base: develop
         add-paths: |

--- a/.github/workflows/create-reports.yml
+++ b/.github/workflows/create-reports.yml
@@ -113,6 +113,8 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
+        # Use a custom PAT because GITHUB_TOKEN cannot trigger subsequent workflows (here: required checks on pull_request).
+        # S. https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
         token: ${{ secrets.PAT_PR_TRIGGERED_BY_ACTIONS }}
         branch: ${{ github.ref_name }}-${{ matrix['Repository name'] }}
         base: develop


### PR DESCRIPTION
I have created a "machine user" **osp-reports-creator** and a PAT for this user which is stored in `secrets.PAT_PR_TRIGGERED_BY_ACTIONS`.
PRs are then created in the context of this user (like [here](https://github.com/Open-Systems-Pharmacology/OSP-Qualification-Reports/pull/111)) and the check workflows are properly triggered on pull_request.

In the 1st attempt, I created this PAT in my own GitHub account - but with this, the action could not assign me as a reviewer, because GitHub does not allow the author of a PR to become its reviewer ([like here](https://github.com/Open-Systems-Pharmacology/OSP-Qualification-Reports/actions/runs/16722591770))
